### PR TITLE
Avoid using service key in client role check

### DIFF
--- a/app/api/admin/create-user/page.tsx
+++ b/app/api/admin/create-user/page.tsx
@@ -30,7 +30,8 @@ export default function CreateUserPage() {
       }
 
       const userEmail = session.user.email!
-      const role = await getUserRole(userEmail, 'face') // 기본 face에서 조회
+      // 브라우저 클라이언트를 사용하여 현재 사용자 권한 조회
+      const role = await getUserRole(userEmail)
 
       if (role === 'admin') {
         setAuthorized(true)

--- a/lib/getUserRole.ts
+++ b/lib/getUserRole.ts
@@ -1,8 +1,10 @@
 // /lib/getUserRole.ts
-import { createClient } from './supabase-admin'
+// 클라이언트에서 사용자 권한을 조회하기 위한 유틸
+// 서비스 로드 키를 노출하지 않기 위해 브라우저 클라이언트를 사용합니다.
+import { createClient } from './supabase'
 
-export async function getUserRole(email: string, source: 'face' | 'lifting') {
-  const supabase = createClient(source)
+export async function getUserRole(email: string) {
+  const supabase = createClient()
   const { data, error } = await supabase
     .from('users')
     .select('role')


### PR DESCRIPTION
## Summary
- use browser supabase client for role lookup to avoid missing env errors
- update call site in callteam user creation page

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_688ca87fd34c832084422655722118b2